### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/toolkit/proc/gen.py
+++ b/toolkit/proc/gen.py
@@ -1,6 +1,11 @@
 # description: Generate db2proc.h
 # command:     python gen.py
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 byall_header = "ibyref.h"
 
 byref_max_files = 6

--- a/toolkit/proc/gen.py
+++ b/toolkit/proc/gen.py
@@ -1,11 +1,6 @@
 # description: Generate db2proc.h
 # command:     python gen.py
 
-try:
-  xrange          # Python 2
-except NameError:
-  xrange = range  # Python 3
-
 byall_header = "ibyref.h"
 
 byref_max_files = 6
@@ -258,7 +253,7 @@ def perms(n, what):
   p = ""
   if not n:
     return p
-  for i in xrange(2**n):
+  for i in range(2**n):
     s = bin(i)[2:]
     s = "0" * (n-len(s)) + s
     # print s


### PR DESCRIPTION
This PR provides equivalent functionality on both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/db2sock-ibmi on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./toolkit/proc/gen.py:192:36: F821 undefined name 'strw'
        srvpgm_c_byval += '*(fool'+strw+'_t *)iNextVal(layout, '+stri+')'
                                   ^
./toolkit/proc/gen.py:256:12: F821 undefined name 'xrange'
  for i in xrange(2**n):
           ^
2     F821 undefined name 'strw'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree